### PR TITLE
API extension for update messages with link support

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
+
 <root release="3.0" version="3">
-	<announcement text="https://www.fantasygrounds.com/forums/showthread.php?74616-Power-Up\rPower Up v1.3 by Ryan Hagelstrom\rContribution: bmos 2022\rtype: /powerup /powerupman" icon="PowerUp" font="emotefont"/>
+	<announcement text="https://www.fantasygrounds.com/forums/showthread.php?74616-Power-Up\rPower Up v1.5 by Ryan Hagelstrom\rContribution: bmos 2022\rtype: /powerup /powerupman" icon="PowerUp" font="emotefont"/>
 	<properties>
-    	<loadorder>10</loadorder>
+    		<loadorder>10</loadorder>
 		<name>Feature: Power Up</name>
-		<version>1.4</version>
+		<version>1.5</version>
 		<author>Ryan Hagelstrom</author>
 		<description>Show what extensions have been updated since last campaign</description>
 	</properties>

--- a/scripts/PowerUp.lua
+++ b/scripts/PowerUp.lua
@@ -107,10 +107,14 @@ end
 function versionMessages(rMessage, tMessages)
 	if not tMessages then return; end
 	for _, msg in pairs(tMessages) do
+		rMessage.icon = "PowerUpChat"
+		if msg['icon'] then rMessage.icon = msg['icon']; end
+
 		rMessage.text = ""
 		if msg['message'] then rMessage.text = rMessage.text .. msg['message']; end
 		if rMessage.text ~= "" and msg['link'] then rMessage.text = rMessage.text .. '\n'; end
 		if msg['link'] then rMessage.text = rMessage.text .. msg['link']; end
+
 		if rMessage.text ~= "" then Comm.addChatMessage(rMessage); end
 	end
 end

--- a/scripts/PowerUp.lua
+++ b/scripts/PowerUp.lua
@@ -107,6 +107,7 @@ end
 function versionMessages(rMessage, tMessages)
 	if not tMessages then return; end
 	for _, msg in pairs(tMessages) do
+		rMessage.text = ""
 		if msg['message'] then rMessage.text = rMessage.text .. msg['message']; end
 		if rMessage.text ~= "" and msg['link'] then rMessage.text = rMessage.text .. '\n'; end
 		if msg['link'] then rMessage.text = rMessage.text .. msg['link']; end
@@ -121,7 +122,6 @@ function getPowerUp(nodeDB)
 		for sName, tData in pairs(tExtensions) do
 			versionChangeNotification(nodeDB, rMessage, sName, tData)
 
-			rMessage.text = ""
 			versionMessages(rMessage, tData['messages'])
 		end
 	end

--- a/scripts/PowerUp.lua
+++ b/scripts/PowerUp.lua
@@ -130,6 +130,7 @@ function getPowerUp(nodeDB)
 		end
 	end
 	if rMessage.bNoUpdates then
+		rMessage.icon = "PowerUpChat"
 		rMessage.text = "No extension updates detected"
 		Comm.addChatMessage(rMessage)
 	end


### PR DESCRIPTION
example of use:
```
function onInit()
	PowerUp.registerExtension('AAA: TEST', '0.9', {
			{
				['link'] = "https://github.com/FG-Unofficial-Developers-Guild/",
				['message'] = "v0.9\nAdded registration code"
			},
			{
				['link'] = "https://fgapp.idea.informer.com/",
				['message'] = "Please vote for this on the idea informer wishlist",
				['icon'] = "shooting_star"
			},
		}
	)
end```